### PR TITLE
Fix encoding for basic authentication

### DIFF
--- a/src/aiontfy/ntfy.py
+++ b/src/aiontfy/ntfy.py
@@ -45,7 +45,9 @@ class Ntfy:
         self._headers = None
 
         if username is not None and password is not None:
-            self._headers = {"Authorization": BasicAuth(username, password).encode()}
+            self._headers = {
+                "Authorization": BasicAuth(username, password, "utf8").encode()
+            }
         elif token is not None:
             self._headers = {"Authorization": f"Bearer {token}"}
 


### PR DESCRIPTION
`BasicAuth` uses latin1 encoding by default, but ntfy expects utf-8 encoding